### PR TITLE
Implement formatted note-display (Closes #7)

### DIFF
--- a/src/components/Notes/Note.tsx
+++ b/src/components/Notes/Note.tsx
@@ -36,7 +36,10 @@ const Note = (props: NoteProps) => {
       </Modal>
     );
   };
-
+  console.log(`body : ${props.note.body}`);
+  const asHtml = (text: string) => {
+    return text.replace(/\n/g, '<br/>');
+  }
   return (
     <div className="note-display" onClick={() => setIsEditing(true)}>
       {renderModal()}
@@ -48,8 +51,9 @@ const Note = (props: NoteProps) => {
       </div>
 
       <div className="display-body-container">
-        <div className="note-display-body">
-          <p>{props.note.body}</p>
+        <div 
+          className="note-display-body"
+          dangerouslySetInnerHTML={{__html: asHtml(props.note.body)}}>
         </div>
       </div>
       <NoteControls />


### PR DESCRIPTION
This is a first-pass implementation. It parses the note body, transforming `\n` to `<br/>`, then uses `dangerouslySetInnerHTML` to display the formatted text. The side-effect is that it means any arbitrary HTML can be put into the note and it will be rendered.

In general we don't really care - but there are some implications to consider once we have sharing implemented. Also, allowing arbitrary HTML just doesn't feel clean. We'll need to think about this once we're past the MVP.

